### PR TITLE
Fix index error for some corner cases

### DIFF
--- a/src/cofix/main/Repair.java
+++ b/src/cofix/main/Repair.java
@@ -452,6 +452,7 @@ public class Repair {
 		
 		// validate patch using failed test cases
 		for(String testcase : _failedTestCases){
+			if (!testcase.contains("::")) continue;
 			String[] testinfo = testcase.split("::");
 			if(!Runner.testSingleTest(_subject, testinfo[0], testinfo[1])){
 				return ValidateStatus.TEST_FAILED;

--- a/src/cofix/main/Repair.java
+++ b/src/cofix/main/Repair.java
@@ -452,6 +452,10 @@ public class Repair {
 		
 		// validate patch using failed test cases
 		for(String testcase : _failedTestCases){
+			//For some special cases where initialization errors happen, 
+			//the output of failing test will be <testClass> instead of 
+			//<testClass::testMethod>. To avoid list index out of range
+			//error, we need to check whether the format is <testClass::testMethod>.
 			if (!testcase.contains("::")) continue;
 			String[] testinfo = testcase.split("::");
 			if(!Runner.testSingleTest(_subject, testinfo[0], testinfo[1])){


### PR DESCRIPTION
When there is a JUnit Initialization Error, it will report only the class name instead of class_name::method_name.